### PR TITLE
allow an optional CSS file name

### DIFF
--- a/pixate-freestyle/src/com/pixate/freestyle/PixateFreestyle.java
+++ b/pixate-freestyle/src/com/pixate/freestyle/PixateFreestyle.java
@@ -18,7 +18,7 @@ package com.pixate.freestyle;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import android.annotation.TargetApi;
 import android.app.ActionBar;
@@ -104,8 +104,8 @@ public class PixateFreestyle {
 
     private static final String TAG = PixateFreestyle.class.getSimpleName();
     public static final boolean ICS_OR_BETTER = Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH;
-    public static String DEFAULT_CSS = "default.css";
-    private static AtomicBoolean cssLoaded = new AtomicBoolean(false);
+    private static String DEFAULT_CSS = "default.css";
+    private static AtomicReference<String> currentCSS = new AtomicReference<String>();
 
     private static Object mLifecycleCallbacks = null;
 
@@ -113,11 +113,21 @@ public class PixateFreestyle {
     private static Context mAppContext = null;
 
     /**
-     * Initialize Pixate with the given {@link Context}.
-     * 
+     * Initialize Pixate with the given {@link Context}, using the styles in default.css.
+     *
      * @param context
      */
     public static void init(Context context) {
+        init(context, DEFAULT_CSS);
+    }
+
+    /**
+     * Initialize Pixate with the given {@link Context} and CSS file.
+     *
+     * @param context
+     * @param cssFileName The CSS file to load styles from
+     */
+    public static void init(Context context, String cssFileName) {
         if (mAppContext == null) {
             mAppContext = context.getApplicationContext();
             // log a version
@@ -125,10 +135,10 @@ public class PixateFreestyle {
                     getApiVersion()));
         }
 
-        if (!cssLoaded.getAndSet(true)) {
+        if (cssFileName != currentCSS.getAndSet(cssFileName)) {
             // try to load the default CSS ones.
             PXStylesheet stylesheet = PXStylesheet.getStyleSheetFromFilePath(
-                    context.getApplicationContext(), DEFAULT_CSS, PXStyleSheetOrigin.APPLICATION);
+                    context.getApplicationContext(), cssFileName, PXStyleSheetOrigin.APPLICATION);
             if (stylesheet != null) {
                 logErrors(stylesheet.getErrors());
             }


### PR DESCRIPTION
This pull request implements the functionality I described in #26.

Essentially, it adds a new, optional init function, of the form `PixateFreestyle.init(context, 'my_theme.css')`. If the selected CSS file has already been applied, nothing happens, just like now. If no CSS has been applied, or if the init function is called with a different CSS file than the current one, the init process is run with the new file.

I'm using this in my own app, and it seems to be working fine.
